### PR TITLE
Added option to display the game played by the streamer

### DIFF
--- a/apps.twitch-indicator.gschema.xml
+++ b/apps.twitch-indicator.gschema.xml
@@ -13,6 +13,12 @@
       <description>When followed channel goes live, will show a notification.</description>
     </key>
 
+    <key type="b" name="show-game-playing">
+      <default>true</default>
+      <summary>Show played game</summary>
+      <description>Shows the game the streamer is playing in the notification as well.</description>
+    </key>
+
     <key type="i" name="refresh-interval">
       <default>5</default>
       <summary>Refresh interval.</summary>

--- a/twitch-indicator.glade
+++ b/twitch-indicator.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="adjustment1">
@@ -57,6 +57,19 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
+        <property name="top_attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Shows notifications when your followed channels go live.</property>
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">Show game played:</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
         <property name="top_attach">2</property>
       </packing>
     </child>
@@ -79,6 +92,17 @@
       <packing>
         <property name="left_attach">1</property>
         <property name="top_attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="show_game">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">start</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">2</property>
       </packing>
     </child>
     <child>
@@ -111,7 +135,7 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">2</property>
+        <property name="top_attach">3</property>
       </packing>
     </child>
   </object>

--- a/twitch-indicator.py
+++ b/twitch-indicator.py
@@ -6,8 +6,6 @@ import json
 from urllib.request import urlopen, Request, HTTPError
 import gi
 
-from pprint import pprint
-
 gi.require_version('AppIndicator3', '0.1')
 gi.require_version('Notify', '0.7')
 gi.require_version('Gtk', '3.0')
@@ -235,6 +233,8 @@ class Indicator:
             self.settings.get_string('twitch-username'))
         builder.get_object('show_notifications').set_active(
             self.settings.get_boolean('enable-notifications'))
+        builder.get_object('show_game').set_active(
+            self.settings.get_boolean('show-game-playing'))
         builder.get_object('refresh_interval').set_value(
             self.settings.get_int('refresh-interval'))
 
@@ -249,6 +249,9 @@ class Indicator:
             self.settings.set_boolean(
                 'enable-notifications',
                 builder.get_object('show_notifications').get_active())
+            self.settings.set_boolean(
+                'show-game-playing',
+                builder.get_object('show_game').get_active())
             self.settings.set_int(
                 'refresh-interval',
                 builder.get_object('refresh_interval').get_value_as_int())
@@ -420,10 +423,14 @@ class Indicator:
             image = gtk.Image()
             # Show default if channel owner has not set his avatar
 
+            body = str(stream['title'])
+            if self.settings.get_boolean('show-game-playing'):
+                body = f"Currently playing: {stream['game']}\n{body}"
+
             Notify.init('Twitch Notification')
             n = Notify.Notification.new(
                 f"{stream['name']} just went LIVE!",
-                stream['title'],
+                body,
                 '')
 
             # Fixed deprecation warning


### PR DESCRIPTION
Reinstall from AUR works just fine.

If you run into issues copy over the modified schema and do
```
$ glib-compile-schemas /usr/share/glib-2.0/schemas
$ dconf write "/apps/twitch-indicator/show-game-playing" "true"
```
to apply schema changes