### PR TITLE
Custom command for opening streams

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.pylintEnabled": true
-}

--- a/data/apps.twitch-indicator.gschema.xml
+++ b/data/apps.twitch-indicator.gschema.xml
@@ -26,9 +26,9 @@
     </key>
 
     <key type="s" name="open-command">
-      <default>firefox {url}</default>
+      <default>"{browser} {url}"</default>
       <summary>Open Command</summary>
-      <description>Which command is used to open the stream.</description>
+      <description>Which command is used to open the stream. {browser} and {url} are available as the default browser and the url of the stream.</description>
     </key>
 
     <key type="i" name="refresh-interval">

--- a/data/apps.twitch-indicator.gschema.xml
+++ b/data/apps.twitch-indicator.gschema.xml
@@ -25,6 +25,12 @@
       <description>Shows viewer count in notifications and menu.</description>
     </key>
 
+    <key type="s" name="open-command">
+      <default>firefox {url}</default>
+      <summary>Open Command</summary>
+      <description>Which command is used to open the stream.</description>
+    </key>
+
     <key type="i" name="refresh-interval">
       <default>5</default>
       <summary>Refresh interval.</summary>

--- a/twitch_indicator/data/twitch-indicator-settings.glade
+++ b/twitch_indicator/data/twitch-indicator-settings.glade
@@ -66,6 +66,18 @@
       </packing>
     </child>
     <child>
+      <object class="GtkLabel" id="label3">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">end</property>
+        <property name="label" translatable="yes">Open command:</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">3</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkLabel" id="label7">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
@@ -74,7 +86,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">3</property>
+        <property name="top_attach">4</property>
       </packing>
     </child>
     <child>
@@ -97,6 +109,17 @@
       <packing>
         <property name="left_attach">1</property>
         <property name="top_attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="open_command">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">start</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">3</property>
       </packing>
     </child>
     <child>
@@ -129,7 +152,7 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">3</property>
+        <property name="top_attach">4</property>
       </packing>
     </child>
   </object>

--- a/twitch_indicator/indicator.py
+++ b/twitch_indicator/indicator.py
@@ -1,4 +1,5 @@
 import webbrowser
+import os
 from urllib.request import HTTPError
 
 from gi.repository import AppIndicator3
@@ -160,4 +161,6 @@ class Indicator:
 
     def on_stream_menu(self, _, url):
         """Callback for stream menu item."""
-        webbrowser.open_new_tab(url)
+        browser = webbrowser.get().basename
+        cmd = self.app.settings.get().get_string("open-command")
+        os.system(cmd.format(url=url, browser=browser))

--- a/twitch_indicator/notifications.py
+++ b/twitch_indicator/notifications.py
@@ -1,4 +1,5 @@
 import webbrowser
+import os
 
 from gi.repository import Notify
 
@@ -71,4 +72,6 @@ class Notifications:
     @staticmethod
     def on_notification_watch(_, __, url):
         """Callback for notification stream watch action."""
-        webbrowser.open_new_tab(url)
+        browser = webbrowser.get().basename
+        cmd = self.app.settings.get().get_string("open-command")
+        os.system(cmd.format(url=url, browser=browser))

--- a/twitch_indicator/settings.py
+++ b/twitch_indicator/settings.py
@@ -34,7 +34,6 @@ class Settings:
         builder.get_object("show_viewer_count").set_active(
             self.settings.get_boolean("show-viewer-count")
         )
-        print("test?")
         builder.get_object("open_command").set_text(
             self.settings.get_string("open-command")
         )

--- a/twitch_indicator/settings.py
+++ b/twitch_indicator/settings.py
@@ -34,6 +34,10 @@ class Settings:
         builder.get_object("show_viewer_count").set_active(
             self.settings.get_boolean("show-viewer-count")
         )
+        print("test?")
+        builder.get_object("open_command").set_text(
+            self.settings.get_string("open-command")
+        )
         builder.get_object("refresh_interval").set_value(
             self.settings.get_int("refresh-interval")
         )
@@ -53,6 +57,10 @@ class Settings:
             self.settings.set_boolean(
                 "show-viewer-count",
                 builder.get_object("show_viewer_count").get_active(),
+            )
+            self.settings.set_string(
+                "open-command",
+                builder.get_object("open_command").get_text(),
             )
             self.settings.set_int(
                 "refresh-interval",


### PR DESCRIPTION
I've added support for customizing the command to open the streams with (instead of always using the browser), for use with tools like streamlink.
The change is relatively simple, but it would be a nice feature, I think.