### PR TITLE
Use Popen instead of system to launch command

### DIFF
--- a/twitch_indicator/indicator.py
+++ b/twitch_indicator/indicator.py
@@ -1,5 +1,6 @@
 import webbrowser
 import os
+import subprocess
 from urllib.request import HTTPError
 
 from gi.repository import AppIndicator3
@@ -167,4 +168,5 @@ class Indicator:
         """Callback for stream menu item."""
         browser = webbrowser.get().basename
         cmd = self.app.settings.get().get_string("open-command")
-        os.system(cmd.format(url=url, browser=browser))
+        formated = cmd.format(url=url, browser=browser).split()
+        subprocess.Popen(formated)

--- a/twitch_indicator/notifications.py
+++ b/twitch_indicator/notifications.py
@@ -1,5 +1,6 @@
 import webbrowser
 import os
+import subprocess
 from gi.repository import Notify, GLib
 
 from twitch_indicator.cached_profile_image import CachedProfileImage
@@ -78,4 +79,5 @@ class Notifications:
         """Callback for notification stream watch action."""
         browser = webbrowser.get().basename
         cmd = self.settings.get_string("open-command")
-        os.system(cmd.format(url=url, browser=browser))
+        formated = cmd.format(url=url, browser=browser).split()
+        subprocess.Popen(formated)


### PR DESCRIPTION
Makes open command work with commands that doesn't fork and exit. Using os.system makes twitch-indicator lock up until it return. 