### PR TITLE
Add streams to top menu directly

### DIFF
--- a/data/apps.twitch-indicator.gschema.xml
+++ b/data/apps.twitch-indicator.gschema.xml
@@ -48,5 +48,11 @@
       <summary>Enabled channels.</summary>
       <description>Channels for which notifications are enabled.</description>
     </key>
+
+    <key type="b" name="first-level-live-channels">
+      <default>false</default>
+      <summary>Show live channels in the top menu</summary>
+      <description>Show live channels in the top menu, otherwise live channels will be in their own submenu.</description>
+    </key>
   </schema>
 </schemalist>

--- a/twitch_indicator/app.py
+++ b/twitch_indicator/app.py
@@ -77,7 +77,11 @@ class TwitchIndicatorApp:
 
     def show_settings(self):
         """Show settings dialog."""
-        self.settings.show()
+        self.settings.show(self.on_settings_ok)
+
+    def on_settings_ok(self):
+        """Callback for settings ok button click"""
+        self.indicator.resetup_menu()
 
     def refresh_streams(self):
         """Refresh live streams list. Also push notifications when needed."""

--- a/twitch_indicator/data/twitch-indicator-settings.glade
+++ b/twitch_indicator/data/twitch-indicator-settings.glade
@@ -173,7 +173,8 @@
 
 Available placeholders:
 &lt;tt&gt;{browser}&lt;/tt&gt; - Default browser command
-&lt;tt&gt;{url}&lt;/tt&gt; - Channel URL</property>
+&lt;tt&gt;{url}&lt;/tt&gt; - Channel URL
+&lt;tt&gt;{name}&lt;/tt&gt; - Channel name</property>
             <property name="hexpand">True</property>
           </object>
           <packing>

--- a/twitch_indicator/data/twitch-indicator-settings.glade
+++ b/twitch_indicator/data/twitch-indicator-settings.glade
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <!-- n-columns=2 n-rows=10 -->
+  <!-- n-columns=2 n-rows=11 -->
   <object class="GtkGrid" id="grid1">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -55,22 +55,6 @@
       </packing>
     </child>
     <child>
-      <object class="GtkLabel">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="halign">center</property>
-        <property name="label" translatable="yes">Miscellaneous</property>
-        <attributes>
-          <attribute name="weight" value="bold"/>
-        </attributes>
-      </object>
-      <packing>
-        <property name="left-attach">0</property>
-        <property name="top-attach">7</property>
-        <property name="width">2</property>
-      </packing>
-    </child>
-    <child>
       <object class="GtkSwitch" id="show_viewer_count">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
@@ -80,23 +64,6 @@
       <packing>
         <property name="left-attach">1</property>
         <property name="top-attach">5</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label3">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="tooltip-markup" translatable="yes">Command to run to open live streams.
-
-Available placeholders:
-&lt;tt&gt;{browser}&lt;/tt&gt; - Default browser command
-&lt;tt&gt;{url}&lt;/tt&gt; - Channel URL</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">Open command</property>
-      </object>
-      <packing>
-        <property name="left-attach">0</property>
-        <property name="top-attach">9</property>
       </packing>
     </child>
     <child>
@@ -153,61 +120,6 @@ Available placeholders:
         <property name="left-attach">0</property>
         <property name="top-attach">2</property>
         <property name="width">2</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkLabel" id="label7">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="tooltip-text" translatable="yes">How often the channel list is updated.</property>
-        <property name="halign">start</property>
-        <property name="label" translatable="yes">Refresh interval</property>
-      </object>
-      <packing>
-        <property name="left-attach">0</property>
-        <property name="top-attach">8</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <child>
-          <object class="GtkSpinButton" id="refresh_interval">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="tooltip-text" translatable="yes">How often the channel list is updated.</property>
-            <property name="max-length">4</property>
-            <property name="width-chars">4</property>
-            <property name="input-purpose">digits</property>
-            <property name="input-hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
-            <property name="snap-to-ticks">True</property>
-            <property name="numeric">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="label8">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">start</property>
-            <property name="margin-start">8</property>
-            <property name="label" translatable="yes">min.</property>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="left-attach">1</property>
-        <property name="top-attach">8</property>
       </packing>
     </child>
     <child>
@@ -290,7 +202,120 @@ Available placeholders:
       </object>
       <packing>
         <property name="left-attach">1</property>
+        <property name="top-attach">10</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label3">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="tooltip-markup" translatable="yes">Command to run to open live streams.
+
+Available placeholders:
+&lt;tt&gt;{browser}&lt;/tt&gt; - Default browser command
+&lt;tt&gt;{url}&lt;/tt&gt; - Channel URL</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Open command</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">10</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <child>
+          <object class="GtkSpinButton" id="refresh_interval">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="tooltip-text" translatable="yes">How often the channel list is updated.</property>
+            <property name="max-length">4</property>
+            <property name="width-chars">4</property>
+            <property name="input-purpose">digits</property>
+            <property name="input-hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NO_EMOJI | GTK_INPUT_HINT_NONE</property>
+            <property name="snap-to-ticks">True</property>
+            <property name="numeric">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label8">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="margin-start">8</property>
+            <property name="label" translatable="yes">min.</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
         <property name="top-attach">9</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label7">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="tooltip-text" translatable="yes">How often the channel list is updated.</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Refresh interval</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">9</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label5">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="tooltip-text" translatable="yes">Sort selected notification channels to the top of live channels list.</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Show live channels in top menu</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">7</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="first_level_live_channels">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="tooltip-text" translatable="yes">Sort selected notification channels to the top of live channels list.</property>
+        <property name="halign">start</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">7</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
+        <property name="label" translatable="yes">Miscellaneous</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">8</property>
+        <property name="width">2</property>
       </packing>
     </child>
   </object>

--- a/twitch_indicator/indicator.py
+++ b/twitch_indicator/indicator.py
@@ -101,7 +101,7 @@ class Indicator:
 
     def create_channel_menu_items(self, streams, streams_menu, settings):
         """Create menu items from streams array."""
-        for stream in streams:
+        for stream in reversed(streams):
             menu_entry = Gtk.ImageMenuItem()
 
             # Channel icon

--- a/twitch_indicator/indicator.py
+++ b/twitch_indicator/indicator.py
@@ -15,10 +15,11 @@ class Indicator:
         self.first_fetch = True
         self.app = app
         self.app_indicator = AppIndicator3.Indicator.new(
-            "Twitch indicator",
+            "twitch-indicator",
             get_data_filepath("twitch-indicator.svg"),
             AppIndicator3.IndicatorCategory.APPLICATION_STATUS,
         )
+        self.app_indicator.set_title("Twitch Indicator")
         self.app_indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
 
         # Setup menu
@@ -93,6 +94,7 @@ class Indicator:
 
         else:
             menu_item_nolive = Gtk.MenuItem(label="No live channels...")
+            menu_item_nolive.set_sensitive(False)
             self.stream_menu_items.append(menu_item_nolive)
 
         self.menu.show_all()

--- a/twitch_indicator/indicator.py
+++ b/twitch_indicator/indicator.py
@@ -154,7 +154,7 @@ class Indicator:
             label.set_markup(markup)
             label.set_halign(Gtk.Align.START)
             menu_entry.add(label)
-            menu_entry.connect("activate", self.on_stream_menu, stream["url"])
+            menu_entry.connect("activate", self.on_stream_menu, stream["url"], stream["name"])
 
             self.stream_menu_items.append(menu_entry)
             streams_menu_func(menu_entry)
@@ -193,9 +193,9 @@ class Indicator:
         """Callback for settings menu item."""
         self.app.show_settings()
 
-    def on_stream_menu(self, _, url):
+    def on_stream_menu(self, _, url, name):
         """Callback for stream menu item."""
         browser = webbrowser.get().basename
         cmd = self.app.settings.get().get_string("open-command")
-        formated = cmd.format(url=url, browser=browser).split()
+        formated = cmd.format(url=url, browser=browser, name=name).split()
         subprocess.Popen(formated)

--- a/twitch_indicator/settings.py
+++ b/twitch_indicator/settings.py
@@ -18,7 +18,7 @@ class Settings:
         """Return settings object."""
         return self.settings
 
-    def show(self):
+    def show(self, on_ok_click):
         """Shows applet settings dialog."""
         if self.dialog:
             self.dialog.present()
@@ -46,6 +46,9 @@ class Settings:
         )
         builder.get_object("show_selected_channels_on_top").set_active(
             self.settings.get_boolean("show-selected-channels-on-top")
+        )
+        builder.get_object("first_level_live_channels").set_active(
+            self.settings.get_boolean("first-level-live-channels")
         )
         self.entry_open_command = builder.get_object("open_command")
         self.entry_open_command.set_text(self.settings.get_string("open-command"))
@@ -84,6 +87,10 @@ class Settings:
                 "show-selected-channels-on-top",
                 builder.get_object("show_selected_channels_on_top").get_active(),
             )
+            self.settings.set_boolean(
+                "first-level-live-channels",
+                builder.get_object("first_level_live_channels").get_active(),
+            )
             self.settings.set_string(
                 "open-command",
                 builder.get_object("open_command").get_text(),
@@ -92,6 +99,8 @@ class Settings:
                 "refresh-interval",
                 builder.get_object("refresh_interval").get_value_as_int(),
             )
+
+            on_ok_click()
 
         try:
             self.dialog.destroy()


### PR DESCRIPTION
Add streams to top menu directly and change the title and id of the AppIndicator to be more appropriate.

Hopefully you consider this a full improvement over the old style so there is no need for an option.